### PR TITLE
The chest folder only exists if you have chests; don't treat as fatal error

### DIFF
--- a/tts/filesystem.py
+++ b/tts/filesystem.py
@@ -32,10 +32,14 @@ class FileSystem:
 
   def check_dirs(self):
     """Do all the directories exist?"""
-    for dir in [ self._saves, self._chest, self._mods, self._images, self._models, self._workshop ]:
+    for dir in [ self._saves, self._mods, self._images, self._models, self._workshop ]:
+      if not os.path.isdir(dir):
+        tts.logger().error("TTS Dir missing: {}".format(dir))
+        return False
+    #These directories don't always exist, and that's OK
+    for dir in [ self._chest ]:
       if not os.path.isdir(dir):
         tts.logger().warn("TTS Dir missing: {}".format(dir))
-        return False
     return True
 
   def create_dirs(self):


### PR DESCRIPTION
I think this fixes #17.

Need to check, but I'm willing to bet the Save folder doesn't exist if a user doesn't have saved games. Not sure if the mods folder is guaranteed to exist either. Should we instead just check if at least one of these folders exists?